### PR TITLE
Fix incorrect supperior limits.

### DIFF
--- a/miv-rv32im-interrupt-blinky/riscv_hal/init.c
+++ b/miv-rv32im-interrupt-blinky/riscv_hal/init.c
@@ -35,7 +35,7 @@ extern uint32_t     __bss_end;
 
 static void copy_section(uint32_t * p_load, uint32_t * p_vma, uint32_t * p_vma_end)
 {
-    while(p_vma <= p_vma_end)
+    while(p_vma < p_vma_end)
     {
         *p_vma = *p_load;
         ++p_load;
@@ -47,7 +47,7 @@ static void zero_section(uint32_t * start, uint32_t * end)
 {
     uint32_t * p_zero = start;
     
-    while(p_zero <= end)
+    while(p_zero < end)
     {
         *p_zero = 0;
         ++p_zero;


### PR DESCRIPTION
Fix incorrect supperior limits on copy_section & zero_section, these functions before the fix read from ROM memory and write to the RAM one extra word.